### PR TITLE
Android specialization fix

### DIFF
--- a/Lua/Buildings/DroneFactory.lua
+++ b/Lua/Buildings/DroneFactory.lua
@@ -213,7 +213,10 @@ function DroneFactory:SpawnAndroid(delay)
 	colonist_table.dome = self.parent_dome
 	colonist_table.current_dome = self.parent_dome
 	colonist_table.traits["Android"] = true
-	colonist_table.specialist = "none"
+	local spec = colonist_table.specialist
+	colonist_table.traits[spec]=nil
+	colonist_table.traits["none"]=true
+	colonist_table.specialist="none"	
 	local colonist = Colonist:new(colonist_table)
 	self:OnEnterUnit(colonist)
 	self:UpdateUI()


### PR DESCRIPTION
The Opportunity patch adjusted the android/biorobot spawn code to cause them to spawn without specializations.  Unfortunately the default change will not completely work, as the default code does not unset their specialization properly. Due to this, most androids will not be able to attend college.

You can verify this by spawning several androids and checking their traits in console. Those that did not have a specialization assigned from the GenerateColonistData function (traits.none) will attend college properly. However, those that did have a specialization assigned will show as 'no specialization' but their specialization trait will still be enabled (traits.medic, traits.engineer) and they won't attend college ever.

I had developed a mod adjusting the android spawn code prior to the patch and ran into the same issue, so I've added my code to this PR. 

Using the colonist methods to remove the trait won't work as the 'colonist' is just a table of traits at this point.  However, a better fix may be adding another parameter to the GenerateColonistData function to request a colonist with an unset specialization. 