### PR TITLE
Enable the ModManager for Linux/MacOSX GoG users

### DIFF
--- a/Lua/XTemplates/PGMenu.lua
+++ b/Lua/XTemplates/PGMenu.lua
@@ -259,7 +259,7 @@ CreateRealTimeThread(function()
 	host:SetMode("ModManager")
 end)
 end,
-						'__condition', function (parent, context) return Platform.steam or Platform.pc end,
+						'__condition', function (parent, context) return Platform.steam or Platform.pc or Platform.linux or Platform.osx end,
 					}),
 					PlaceObj('XTemplateAction', {
 						'ActionId', "idModEditor",


### PR DESCRIPTION
While the GoG version of the game is not able to access the Steam Workshop, people who have bought that version of the game should still be able to activate and deactivate mods that they have manually downloaded (e.g. from Github, or NexusMods, etc). Restricting the ModManager to PC/Steam only means that GoG users _cannot_ activate and deactivate mods that they have downloaded manually.

The ModManager is not the ModEditor. It is not a Windows-only function. It should not be hidden from users on non-Windows operating systems.

See also: https://forum.paradoxplaza.com/forum/index.php?threads/surviving-mars-no-mod-manager.1101281/#post-24315107