### PR TITLE
Fix setting of avoid_workplace on firing

### DIFF
--- a/Lua/Units/Colonist.lua
+++ b/Lua/Units/Colonist.lua
@@ -1176,9 +1176,9 @@ function Colonist:GetFired()
 	if not self.workplace then
 		return
 	end
-	self:SetWorkplace(false)
 	self.avoid_workplace = self.workplace
 	self.avoid_workplace_start = self.city.day
+	self:SetWorkplace(false)
 	self:ChangeWorkplacePerformance()
 end
 


### PR DESCRIPTION
`GetFired` sets `avoid_workplace` to `current_workplace`, but only after `current_workplace` has been set to false.
Surely this should be the other way around?

I confirmed this bug in game: If there are no other eligible workplaces, a fired worker will immediately resume work at the workplace they were just fired from. They should not work there until AvoidWorkplaceSols have passed.